### PR TITLE
cmd/netsetgo: Enforce pid argument

### DIFF
--- a/cmd/netsetgo.go
+++ b/cmd/netsetgo.go
@@ -23,6 +23,11 @@ func main() {
 	flag.IntVar(&pid, "pid", 0, "pid of a process in the container's network namespace")
 	flag.Parse()
 
+	if pid == 0 {
+		fmt.Println("ERROR - netsetgo needs a pid")
+		os.Exit(1)
+	}
+
 	bridgeCreator := device.NewBridge()
 	vethCreator := device.NewVeth()
 	netnsExecer := &netns.Execer{}

--- a/integration_test.go
+++ b/integration_test.go
@@ -13,6 +13,14 @@ import (
 )
 
 var _ = Describe("netsetgo binary", func() {
+	Context("when an invalid pid is provided", func() {
+		It("exits 1", func() {
+			command := exec.Command(pathToNetsetgo)
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+		})
+	})
 	Context("when passed all required args", func() {
 		var (
 			parentPid int


### PR DESCRIPTION
If we call netsetgo without arguments, it returns an error:
ERROR - no such process

It fails because Veth.MoveToNetworkNamespace calls
netlink.LinkSetNsPid, which needs a pid that belongs to another netns in
order to set a veth interface inside the new netns.

So, before doing any setup, check if a pid was passed as argument of
netsetgo.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>