### PR TITLE
cmd/netsetgo: Can't be executed by an ordinary user

### DIFF
--- a/cmd/netsetgo.go
+++ b/cmd/netsetgo.go
@@ -23,6 +23,12 @@ func main() {
 	flag.IntVar(&pid, "pid", 0, "pid of a process in the container's network namespace")
 	flag.Parse()
 
+	if os.Geteuid() != 0 {
+		fmt.Println("ERROR - netsetgo must have root access")
+		fmt.Println("netsetgo needs CAP_SYS_ADMIN, setuid, or being executed as root")
+		os.Exit(1)
+	}
+
 	if pid == 0 {
 		fmt.Println("ERROR - netsetgo needs a pid")
 		os.Exit(1)


### PR DESCRIPTION
VETH interfaces cannot be created an moved to another netns by an
ordinary user, so return an error and inform the user to run netsetgo
with CAP_SYS_ADMIN, setuid or be executed by root user.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>